### PR TITLE
Gusb/save-request-when-received

### DIFF
--- a/src/RequestLog/Middleware/LogRequest.php
+++ b/src/RequestLog/Middleware/LogRequest.php
@@ -81,7 +81,7 @@ class LogRequest
     }
 
     /**
-     * Writes the RequestLog to the database once the request has terminated
+     * Updates the RequestLog in the database once the request has terminated
      *
      * @param mixed $request
      * @param mixed $response
@@ -91,7 +91,6 @@ class LogRequest
     public function terminate($request, $response): void
     {
         try {
-
             // If the request is blacklisted or request log is not enabled, then receivedRequest was never set.
             if ( ! isset($this->receivedRequest)) {
                 return;

--- a/src/RequestLog/Middleware/LogRequest.php
+++ b/src/RequestLog/Middleware/LogRequest.php
@@ -72,7 +72,6 @@ class LogRequest
                 ]);
             }
         } catch (Throwable $throwable) {
-            echo($throwable->getMessage());
             Log::error($throwable);
         }
 
@@ -102,16 +101,14 @@ class LogRequest
                 $executionTime = 0;
             }
 
-            // Update the receivedRequest with response data, then save changes to the database.
+            // Update the receivedRequest in the database with response data
             $this->receivedRequest->update([
-                'status' => $response->getStatus(),
+                'status' => 5,//$response->getStatus(),
                 'response_headers'   => json_encode($response->headers->all()),
                 'response_body'      => $response->getContent() ?: '{}',
                 'response_exception' => json_encode($response->exception),
                 'execution_time'     => $executionTime,
             ]);
-
-            $this->receivedRequest->save();
 
         } catch (Throwable $throwable) {
             Log::error($throwable);

--- a/src/RequestLog/Middleware/LogRequest.php
+++ b/src/RequestLog/Middleware/LogRequest.php
@@ -55,20 +55,20 @@ class LogRequest
 
                 // Save request to database immediately so that we can see that it was received even if it is timed out
                 $this->receivedRequest = RequestLog::create([
-                    'client_ip' => $request->ip(),
-                    'user_agent' => $request->userAgent(),
-                    'method' => $request->method(),
-                    'status' => 0,
-                    'url' => $request->url(),
-                    'root' => $request->root(),
-                    'path' => $request->path(),
-                    'query_string' => SecurityUtility::getQueryWithMaskingApplied($request),
-                    'request_headers' => SecurityUtility::getHeadersWithMaskingApplied($request),
-                    'request_body' => SecurityUtility::getBodyWithMaskingApplied($request) ?: '{}',
-                    'response_headers' => '[]',
-                    'response_body' => '{}',
+                    'client_ip'          => $request->ip(),
+                    'user_agent'         => $request->userAgent(),
+                    'method'             => $request->method(),
+                    'status'             => 0,
+                    'url'                => $request->url(),
+                    'root'               => $request->root(),
+                    'path'               => $request->path(),
+                    'query_string'       => SecurityUtility::getQueryWithMaskingApplied($request),
+                    'request_headers'    => SecurityUtility::getHeadersWithMaskingApplied($request),
+                    'request_body'       => SecurityUtility::getBodyWithMaskingApplied($request) ?: '{}',
+                    'response_headers'   => '[]',
+                    'response_body'      => '{}',
                     'response_exception' => '[]',
-                    'execution_time' => 0,
+                    'execution_time'     => 0,
                 ]);
             }
         } catch (Throwable $throwable) {
@@ -103,7 +103,7 @@ class LogRequest
 
             // Update the receivedRequest in the database with response data
             $this->receivedRequest->update([
-                'status' => $response->status(),
+                'status'             => $response->status(),
                 'response_headers'   => json_encode($response->headers->all()),
                 'response_body'      => $response->getContent() ?: '{}',
                 'response_exception' => json_encode($response->exception),

--- a/src/RequestLog/Middleware/LogRequest.php
+++ b/src/RequestLog/Middleware/LogRequest.php
@@ -103,7 +103,7 @@ class LogRequest
 
             // Update the receivedRequest in the database with response data
             $this->receivedRequest->update([
-                'status' => 5,//$response->getStatus(),
+                'status' => $response->getStatus(),
                 'response_headers'   => json_encode($response->headers->all()),
                 'response_body'      => $response->getContent() ?: '{}',
                 'response_exception' => json_encode($response->exception),

--- a/src/RequestLog/Middleware/LogRequest.php
+++ b/src/RequestLog/Middleware/LogRequest.php
@@ -103,7 +103,7 @@ class LogRequest
 
             // Update the receivedRequest in the database with response data
             $this->receivedRequest->update([
-                'status' => $response->getStatus(),
+                'status' => $response->status(),
                 'response_headers'   => json_encode($response->headers->all()),
                 'response_body'      => $response->getContent() ?: '{}',
                 'response_exception' => json_encode($response->exception),

--- a/tests/Unit/LogRequestTest.php
+++ b/tests/Unit/LogRequestTest.php
@@ -166,17 +166,15 @@ class LogRequestTest extends TestCase
     public function it_saves_request_to_db_immediately_when_received()
     {
         // Arrange
-        $req = Request::create("something");
+        $request = Request::create("something");
         $service = new RequestLogOptionsService();
         $requestLog = new LogRequest($service);
 
         // Act -> mock closure given to ensure terminate function is not hit
-        $requestLog->handle($req, function ($r) {});
+        $requestLog->handle($request, function ($r) {});
 
         // Assert
         $this->assertDatabaseCount('request_logs', 1);
-        $reqLog = RequestLog::query()->firstOrFail();
-        $this->assertEquals(0, $reqLog->status);
-        $this->assertEquals("http://localhost/something", $reqLog->url);
+        $this->assertDatabaseHas(RequestLog::class, ["status" => 0, "url" => "http://localhost/something"]);
     }
 }


### PR DESCRIPTION
1. Handle function in LogRequest now saves incoming requests immediately. Terminate function then updates the request log with the data from the response. Before, LogRequest would only be saved in the terminate function.

Link to the trello card: 
https://trello.com/c/ISJsAAJh/379-opdater-request-logs-pakken-til-at-gemme-requestet-n%C3%A5r-det-modtages-og-opdatere-med-svaret-til-sidst