### PR TITLE
Add Laravel v13 support to illuminate package constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "nesbot/carbon": "^2.17|^3.0",
-        "illuminate/http": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/http": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "orchestra/testbench": "^10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9640889ff9c25a1b7e3d1276c187b044",
+    "content-hash": "cb4eb2dc1ebb7a4abe68fe6437188275",
     "packages": [
         {
             "name": "brick/math",
@@ -10030,7 +10030,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -10038,6 +10038,6 @@
         "ext-json": "*",
         "ext-mbstring": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Adds `^13.0` to all `illuminate/*` version constraints and updates the lock file.